### PR TITLE
Autotrader update

### DIFF
--- a/src/css/autotrader.scss
+++ b/src/css/autotrader.scss
@@ -29,7 +29,7 @@
         border-radius:10px;
         color:$text-dark;
         text-align:center;
-        
+
         @media (max-width:1550px) {
             & { width:80vw;}
         }
@@ -68,7 +68,7 @@
 }
 
 .trade-metrics {
-    padding:10px 0;
+    margin:10px 0;
     display:flex;
     flex-direction:row;
     justify-content:center;
@@ -92,6 +92,14 @@
     span.countdown-number {
         font-family: WorkSansSemiBold;
         color:rgb(147, 139, 255);
+    }
+}
+
+.trade-balance {
+    margin: 10px 0;
+
+    span {
+        font-family: WorkSansSemiBold;
     }
 }
 
@@ -149,7 +157,7 @@
                         width:50%;
                     }
                     @media (max-width:1300px) {
-                        & { 
+                        & {
                             height:45px;
                             width:45px;
                         }
@@ -216,7 +224,7 @@
             overflow:hidden;
             transform:translate(0,0);
 
-            
+
             .dark & {
                 border:2px solid rgb(109, 109, 109);
                 background:rgb(27, 27, 27);
@@ -225,12 +233,12 @@
             &.trade-rule-neutral {border-color: rgb(71, 99, 255);}
             &.trade-rule-buy {border-color:rgb(74, 228, 133);}
             &.trade-rule-sell {border-color:rgb(255, 77, 77);}
-            
+
             &.trade-rule-disabled {
                 filter:brightness(0.6);
                 opacity:0.6;
             }
-            
+
             .trade-rule-item-content {
                 z-index:19000;
                 width:100%;
@@ -243,7 +251,7 @@
                 position:relative;
                 background:none;
                 flex-wrap:wrap;
-                
+
                 //background:rgba(245, 56, 42, 0.171);
             }
 
@@ -384,7 +392,7 @@
                         border:1px solid rgb(97, 97, 97);
                     }
                     .step-quant {
-                        flex: 1; 
+                        flex: 1;
                         font-family:WorkSansSemiBold;
                         border-right:1px solid rgb(124, 124, 124);
                     }
@@ -479,8 +487,8 @@
                     }
                 }
             }
-            
-            
+
+
             @media (max-width:1350px) {
                 //height:60px;
                 margin:4px;

--- a/src/js/actions/actions.ts
+++ b/src/js/actions/actions.ts
@@ -84,7 +84,9 @@ export const autotraderActions = createActions(
     {
         SET_RUNNING: running => ({ running }),
         SET_RULES: rules => ({ rules }),
-        SET_NEXT_TRADE_TIME: nextTradeTime => ({ nextTradeTime })
+        SET_NEXT_TRADE_TIME: nextTradeTime => ({ nextTradeTime }),
+        SET_EXPECTED_BALANCE: expectedBalance => ({expectedBalance}),
+        SET_PENDING_ORDER: pendingOrder => ({ pendingOrder })
     }
 )
 

--- a/src/js/components/autotrader/TradeRuleItem.tsx
+++ b/src/js/components/autotrader/TradeRuleItem.tsx
@@ -4,16 +4,17 @@ import {
     IoIosArrowDown,
     IoIosArrowUp
 } from 'react-icons/io';
-import { TransactionType } from '../../interfaces/ITransaction';
+import { Order, TransactionType } from '../../interfaces/ITransaction';
 import numberWithCommas from '../../numberWithCommas';
 import Coin from '../Coin';
 
-import { 
+import {
     BiPlus,
     BiMinus
 } from 'react-icons/bi';
 
 interface TradeRuleItemProps {
+    pendingOrder:Array<Order>,
     coin:string,
     price:number,
     saleValue:number,
@@ -53,7 +54,7 @@ class TradeRuleItem extends Component<TradeRuleItemProps> {
             amt = 0;
         } else {
             let textv:string = a.target.value;
-            if(textv.slice(-1) === ".") textv = textv + "0"; 
+            if(textv.slice(-1) === ".") textv = textv + "0";
             amt = parseFloat(textv);
         }
         if(isNaN(amt)) amt = 0;
@@ -135,13 +136,14 @@ class TradeRuleItem extends Component<TradeRuleItemProps> {
             }
         }
 
-        if(this.props.type === TransactionType.SELL && this.props.quantity === 0) {
+        let inOrder = false;
+        for(let i = 0; i < this.props.pendingOrder.length; i++)
+            if(this.props.pendingOrder[i].coin == this.props.coin) {
+                inOrder = true;
+                break;
+            }
+        if(!inOrder)
             className += " trade-rule-disabled";
-        }
-
-        if(this.props.type === TransactionType.BUY && (this.props.price > this.props.balance)) {
-            className += " trade-rule-disabled";
-        }
 
         return(
             <Draggable
@@ -150,12 +152,12 @@ class TradeRuleItem extends Component<TradeRuleItemProps> {
                 key={this.props.coin}>
 
                 {(providedDrag:any) => (
-                <div 
+                <div
                     className={className}
                     {...providedDrag.draggableProps}
                     ref={providedDrag.innerRef}>
                     <div className="trade-rule-item-content">
-                        <div 
+                        <div
                             className="trade-priority flex flex-col flex-center"
                             {...providedDrag.dragHandleProps}>
                             <IoIosArrowUp />
@@ -164,19 +166,19 @@ class TradeRuleItem extends Component<TradeRuleItemProps> {
                         <div className="trade-rule-coin">
                             <Coin name={this.props.coin}/>
                         </div>
-                        <div 
+                        <div
                             className="trade-rule-info"
                             title={"Mean purchase price: $" + numberWithCommas(this.props.meanPurchasePrice)}>
                             <div className="trade-rule-info-label">Current Price</div>
                             <div className="trade-rule-price">${numberWithCommas(this.props.price)}</div>
                         </div>
-                        <div 
+                        <div
                             className="trade-rule-info"
                             title={"Mean purchase price: $" + numberWithCommas(this.props.meanPurchasePrice)}>
                             <div className="trade-rule-info-label">Sale Value</div>
                             <div className="trade-rule-price">${numberWithCommas(this.props.saleValue)}</div>
                         </div>
-                        <div 
+                        <div
                             className="trade-rule-info">
                             <div className="trade-rule-info-label">Volume</div>
                             <div className="trade-rule-volume">{numberWithCommas(this.props.volume)}</div>
@@ -206,8 +208,8 @@ class TradeRuleItem extends Component<TradeRuleItemProps> {
                                 <div className="decrement" title="Subtract 100" onClick={() => this.increment(-100)}><BiMinus/></div>
                                 <div className="decrement" title="Subtract 10" onClick={() => this.increment(-10)}><BiMinus/></div>
                                 <div className="decrement" title="Subtract 1" onClick={() => this.increment(-1)}><BiMinus/></div>
-                                <input 
-                                    type="text" 
+                                <input
+                                    type="text"
                                     maxLength={5}
                                     value={this.props.targetQuantity}
                                     onChange={(
@@ -220,7 +222,7 @@ class TradeRuleItem extends Component<TradeRuleItemProps> {
                             </div>
                         </div>
                     </div>
-                    <div 
+                    <div
                         className="trade-rule-item-cooldown"
                         style={{
                             width:this.getCooldownWidth() + "%"

--- a/src/js/getTransactionStatus.ts
+++ b/src/js/getTransactionStatus.ts
@@ -5,7 +5,7 @@ import {COOLDOWN} from './components/constants';
 
 const getTransactionStatus = (
         wallet:IWallet,
-        coinData:ICoinData, 
+        coinData:ICoinData,
         name:string,
         verified:boolean,
         muted:boolean,
@@ -29,9 +29,9 @@ const getTransactionStatus = (
     if(sellQuantity > 1) {
         sellRate = sellQuantity * 0.1;
     }
-    let buyRate = 0;
+    let buyRate = 0.05;
     if(buyQuantity > 1) {
-        buyRate = (buyQuantity * 0.1) + 0.05;
+        buyRate += (buyQuantity * 0.1);
     }
 
     let buyFee = Math.max((buyQuantity * price * buyRate) - credits, 0);
@@ -39,12 +39,12 @@ const getTransactionStatus = (
 
     let buyTotal = (buyQuantity * price) + buyFee;
 
-    buyDisabled = 
+    buyDisabled =
         (balance < buyTotal)
         || !verified
         || muted
-        || !marketSwitch; 
-    sellDisabled = 
+        || !marketSwitch;
+    sellDisabled =
         (amtOwned < sellQuantity)
         || (balance + (sellQuantity * saleValue) < sellFee)
         || !verified
@@ -57,7 +57,7 @@ const getTransactionStatus = (
     if((now - lastBought) < e) {
         timeRemaining = e - (now - lastBought);
     }
-    
+
     return {
         timeRemaining,
         buyDisabled,

--- a/src/js/reducers/autotrader.ts
+++ b/src/js/reducers/autotrader.ts
@@ -13,12 +13,22 @@ const autotrader = handleActions(
         SET_NEXT_TRADE_TIME: (state:any, action:any) => ({
             ...state,
             nextTradeTime: action.payload.nextTradeTime
+        }),
+        SET_EXPECTED_BALANCE: (state:any, action:any) => ({
+            ...state,
+            expectedBalance: action.payload.expectedBalance
+        }),
+        SET_PENDING_ORDER: (state:any, action:any) => ({
+            ...state,
+            pendingOrder: action.payload.pendingOrder
         })
     },
     {
         running:false,
         rules:[],
-        nextTradeTime:0
+        nextTradeTime:0,
+        expectedBalance:0,
+        pendingOrder:[]
     }
 )
 

--- a/src/js/store.ts
+++ b/src/js/store.ts
@@ -85,7 +85,9 @@ let initState = {
     autotrader: {
         running:false,
         nextTradeTime:0,
-        rules:[]
+        expectedBalance:0,
+        rules:[],
+        pendingOrder:[]
     },
     itemcatalogue: {},
     admin: {


### PR DESCRIPTION
- added ability to possibly make more trades per round (circumstantial, based on user specified rules)
- now able to buy immediately after selling [to acquire enough capital for aforementioned buy] within the same round, no need to wait out the cooldown
- users can see an expected balance and their net profit/loss after the next round of trading
- autotrader rules more accurately updated to show their current state (if buy/sell is possible and if part of next round)
- fix for buyDisabled by correctly defining taxes/fees